### PR TITLE
Fix "bundle exec jekyll build" for Travis CI

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -176,6 +176,7 @@ exclude:
   - LICENSE
   - README.md
   - Vagrantfile
+  - vendor
 
 # prose.io config
 prose:


### PR DESCRIPTION
Exclude the vendor directory, which contains examples like:
/vendor/bundle/ruby/2.3.0/gems/jekyll-3.5.2/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb

Causing the following error message:

```
Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.3.0/gems/jekyll-3.5.2/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.3.0/gems/jekyll-3.5.2/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

cc @Trybnetic 